### PR TITLE
Added `castArgs` which when `validationSchema` is passed

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -101,7 +101,7 @@ storiesOf('Example', module)
 You can pass any `Formik` component props (initialValues, validationSchema, validateOnBlur, etc) as arguments to a story.
 These props must be passed under the `formik` parameter key.
 
-If no initial values are supplied, `{}` will be used.
+If no initial values are supplied, `{ enableReinitialize: true, initialValues: StoryContext.args || {} }` will be used.
 
 ```tsx
 export const myTextInput = () => (
@@ -121,6 +121,10 @@ myTextInput.parameters = {
   },
 };
 ```
+
+### `formik.castArgs` and `formik.validationSchema`
+
+If a `validationSchema` is provided in the `formik` config and `castArgs: true`, then `validationSchema.cast(initialValues || StoryContext.args || {})` will be called and the result passed in as `initialValues`.
 
 ## Mature Examples
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,8 @@ import {
   EVT_SUBMIT,
 } from './shared';
 
+export { DecoratorParams } from './shared';
+
 export const withFormik = makeDecorator({
   name: 'withFormik',
   parameterName: 'formik',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ export const withFormik = makeDecorator({
 
     return (
       <Formik
-      enableReinitialize
+        enableReinitialize
         onSubmit={(v, { setSubmitting }) => {
           channel.emit(EVT_ON_SUBMIT, v);
           setSubmitting(false);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Formik, Form } from 'formik';
 import addons, { makeDecorator } from '@storybook/addons';
 import {
-  ConfigWithoutSubmit,
+  ConfigWithoutExtra,
   EVT_ON_SUBMIT,
   EVT_RENDER,
   EVT_SUBMIT,
@@ -16,11 +16,23 @@ export const withFormik = makeDecorator({
     const channel = addons.getChannel();
     let submitter: () => void;
     channel.on(EVT_SUBMIT, () => submitter && submitter());
-    const formikConfig = parameters as ConfigWithoutSubmit | undefined;
-    const initialValues = (formikConfig && formikConfig.initialValues) || {};
+    const formikConfig = parameters as ConfigWithoutExtra | undefined;
+    let initialValues =
+      context.args || (formikConfig && formikConfig.initialValues) || {};
+
+    if (
+      context.args &&
+      formikConfig &&
+      !formikConfig.initialValues &&
+      formikConfig.validationSchema &&
+      parameters.castArgs
+    ) {
+      initialValues = formikConfig.validationSchema.cast(initialValues);
+    }
 
     return (
       <Formik
+      enableReinitialize
         onSubmit={(v, { setSubmitting }) => {
           channel.emit(EVT_ON_SUBMIT, v);
           setSubmitting(false);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,12 +20,11 @@ export const withFormik = makeDecorator({
     channel.on(EVT_SUBMIT, () => submitter && submitter());
     const formikConfig = parameters as ConfigWithoutExtra | undefined;
     let initialValues =
-      context.args || (formikConfig && formikConfig.initialValues) || {};
+      (formikConfig && formikConfig.initialValues) || context.args || {};
 
     if (
       context.args &&
       formikConfig &&
-      !formikConfig.initialValues &&
       formikConfig.validationSchema &&
       parameters.castArgs
     ) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -11,7 +11,7 @@ export const EVT_ON_SUBMIT = 'formik/on-submit';
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 export type ConfigWithoutExtra<Values = any> = PartialBy<
-  FormikConfig<Values> & { castArgs?: boolean, initialValues?: Values },
+  Omit<FormikConfig<Values>, 'initialValues'> & { castArgs?: boolean, initialValues?: Values },
   'onSubmit' | 'castArgs'
 >;
 export interface DecoratorParams<Values = any> {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -11,7 +11,7 @@ export const EVT_ON_SUBMIT = 'formik/on-submit';
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 export type ConfigWithoutExtra<Values = any> = PartialBy<
-  FormikConfig<Values> & { castArgs?: boolean },
+  FormikConfig<Values> & { castArgs?: boolean, initialValues?: Values },
   'onSubmit' | 'castArgs'
 >;
 export interface DecoratorParams<Values = any> {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -10,10 +10,10 @@ export const EVT_SUBMIT = 'formik/submit';
 export const EVT_ON_SUBMIT = 'formik/on-submit';
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-export type ConfigWithoutSubmit<Values = any> = PartialBy<
-  FormikConfig<Values>,
-  'onSubmit'
+export type ConfigWithoutExtra<Values = any> = PartialBy<
+  FormikConfig<Values> & { castArgs?: boolean },
+  'onSubmit' | 'castArgs'
 >;
 export interface DecoratorParams<Values = any> {
-  formik: ConfigWithoutSubmit<Values>;
+  formik: ConfigWithoutExtra<Values>;
 }


### PR DESCRIPTION
Added `castArgs` which when `validationSchema` is passed will pass args through `validationSchema.cast(args)` before being set as `initialValues`
