### PR TITLE
fix/register path

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,6 @@ module.exports = {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    '../dist/esm'
+    '../dist/esm/register',
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "storybook-formik",
       "version": "2.3.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- fix: set correct register path in storybook main to enable running storybook locally
- chore: ran npm install

Fix an issue where we could not run storybook in the package because the addon path was not pointed to the register file. Introduced in #42 